### PR TITLE
adding npm start server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "boardgame.io": "0.31.3",
     "bootstrap": "^4.3.1",
+    "concurrently": "^4.1.0",
     "esm": "^3.1.3",
     "react": "16.3.2",
     "react-dom": "16.3.2",
@@ -14,7 +15,8 @@
   },
   "devDependencies": {},
   "scripts": {
-    "start": "react-scripts start",
+    "start": "concurrently - kill-others \"node -r esm src/server.js\" \"react-scripts start\"",
+    "react-start": "react-scripts start",
     "serving": "serve -s build",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",

--- a/src/server.js
+++ b/src/server.js
@@ -3,3 +3,4 @@ const Server = require("boardgame.io/server").Server;
 const TicTacToe = require("./game").TicTacToe;
 const server = Server({ games: [TicTacToe] });
 server.run(8000);
+console.log('\x1b[32m%s\x1b[37m%s\x1b[0m', 'Server.js: ', `server listening on http://localhost:8000`);


### PR DESCRIPTION
I have added a library to execute two servers (concurrently) in one command. After pull, you have to execute `npm install` to install this library.

Once installed you only need to execute `npm start` to execute both servers.

